### PR TITLE
Mapping load

### DIFF
--- a/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
+++ b/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
@@ -1,3 +1,5 @@
+import yaml 
+
 class Task:
     def __init__(self, start, goal, timestep):
         self.start = start
@@ -27,10 +29,20 @@ class Agent:
 
 class Map:
     def __init__(self, map):
-        self.map = map
+        with open(map, "r") as map_file:
+            try:
+                temp = yaml.load(map_file, Loader=yaml.FullLoader)
+                print(temp)
+                print(temp['map'])
+            except yaml.YAMLError as exc:
+                print(exc)
+
 
 
 class Assignment:
     def __init__(self, task: Task, agent: Agent) -> None:
         self.task = task
         self.agent = agent
+
+if __name__ == "__main__":
+    map1 = Map('input.yaml')

--- a/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
+++ b/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
@@ -43,6 +43,3 @@ class Assignment:
     def __init__(self, task: Task, agent: Agent) -> None:
         self.task = task
         self.agent = agent
-
-if __name__ == "__main__":
-    map1 = Map('input.yaml')

--- a/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
+++ b/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
@@ -31,7 +31,7 @@ class Map:
     def __init__(self, map):
         with open(map, "r") as map_file:
             try:
-                self.testmap = yaml.load(map_file, Loader=yaml.FullLoader)['map']
+                self.map_dict = yaml.load(map_file, Loader=yaml.FullLoader)['map']
             except yaml.YAMLError as exc:
                 print(exc)
 

--- a/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
+++ b/multi_agent_path_planning/lifelong_MAPF/datastuctures.py
@@ -31,9 +31,7 @@ class Map:
     def __init__(self, map):
         with open(map, "r") as map_file:
             try:
-                temp = yaml.load(map_file, Loader=yaml.FullLoader)
-                print(temp)
-                print(temp['map'])
+                self.testmap = yaml.load(map_file, Loader=yaml.FullLoader)['map']
             except yaml.YAMLError as exc:
                 print(exc)
 

--- a/multi_agent_path_planning/lifelong_MAPF/helpers.py
+++ b/multi_agent_path_planning/lifelong_MAPF/helpers.py
@@ -10,3 +10,4 @@ def make_agent_dict(input):
     for agent in temp["agents"]:    
         agents[agent['name']] = agent['start']
     return agents
+    

--- a/multi_agent_path_planning/lifelong_MAPF/helpers.py
+++ b/multi_agent_path_planning/lifelong_MAPF/helpers.py
@@ -1,0 +1,12 @@
+import yaml 
+
+def make_agent_dict(input):
+    with open(input, "r") as input_file:
+        try:
+            temp = yaml.load(input_file, Loader=yaml.FullLoader)
+        except yaml.YAMLError as exc:
+            print(exc)
+    agents = {}
+    for agent in temp["agents"]:    
+        agents[agent['name']] = agent['start']
+    return agents

--- a/multi_agent_path_planning/lifelong_MAPF/input.yaml
+++ b/multi_agent_path_planning/lifelong_MAPF/input.yaml
@@ -1,0 +1,14 @@
+agents:
+-   start: [0, 0]
+    goal: [2, 2]
+    name: agent0
+-   start: [2, 2]
+    goal: [0, 0]
+    name: agent1
+map:
+    dimensions: [3, 3]
+    obstacles:
+    - !!python/tuple [0, 1]
+    - !!python/tuple [2, 1]
+
+dynamic_obstacles: {}

--- a/multi_agent_path_planning/lifelong_MAPF/lifelong_MAPF.py
+++ b/multi_agent_path_planning/lifelong_MAPF/lifelong_MAPF.py
@@ -17,8 +17,8 @@ def main():
     args = parser.parse_args()
     
     output = lifelong_MAPF_experiment(
-                Map(args.input),
-                make_agent_dict(args.input),
+                map_instance=Map(args.input),
+                initial_agents=make_agent_dict(args.input),
                 task_factory=BaseTaskFactory(),
                 task_allocator=BaseTaskAllocator(),
                 mapf_solver=BaseMAPFSolver(),

--- a/multi_agent_path_planning/lifelong_MAPF/lifelong_MAPF.py
+++ b/multi_agent_path_planning/lifelong_MAPF/lifelong_MAPF.py
@@ -1,4 +1,5 @@
 import typing
+import argparse
 
 from multi_agent_path_planning.lifelong_MAPF.datastuctures import Agent, Map
 from multi_agent_path_planning.lifelong_MAPF.dynamics_simulator import (
@@ -7,6 +8,26 @@ from multi_agent_path_planning.lifelong_MAPF.dynamics_simulator import (
 from multi_agent_path_planning.lifelong_MAPF.mapf_solver import BaseMAPFSolver
 from multi_agent_path_planning.lifelong_MAPF.task_allocator import BaseTaskAllocator
 from multi_agent_path_planning.lifelong_MAPF.task_factory import BaseTaskFactory
+from multi_agent_path_planning.lifelong_MAPF.helpers import *
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="input file")
+    parser.add_argument("output", help="output file with the schedule")
+    args = parser.parse_args()
+    
+    output = lifelong_MAPF_experiment(
+                Map(args.input),
+                make_agent_dict(args.input),
+                task_factory=BaseTaskFactory(),
+                task_allocator=BaseTaskAllocator(),
+                mapf_solver=BaseMAPFSolver(),
+                dynamics_simulator=BaseDynamicsSimulator(),
+    )
+
+    # refine this later 
+    with open(args.output, "w") as output_yaml:
+        yaml.safe_dump(output, output_yaml)
 
 
 def lifelong_MAPF_experiment(
@@ -93,11 +114,4 @@ def lifelong_MAPF_experiment(
 
 
 if __name__ == "__main__":
-    lifelong_MAPF_experiment(
-        Map(None),
-        initial_agents={},
-        task_factory=BaseTaskFactory(),
-        task_allocator=BaseTaskAllocator(),
-        mapf_solver=BaseMAPFSolver(),
-        dynamics_simulator=BaseDynamicsSimulator(),
-    )
+    main()


### PR DESCRIPTION
added: 

- added arg parse, exact same as deafult, just specify input.yaml and output.yaml
- functionality for loading "inputs" from yaml, this includes the starting locations of the agents, and the map itself
- added a helper to convert the starting agents to the dictionary type you wanted
- added a helper function file which we can use for general functions that may be homeless 